### PR TITLE
Fix some grammar in README.MD

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 WLambda - Embeddable Scripting Language for Rust
 ================================================
 
-This crate provides you with a small and simple embeddable scripting language.
-It's syntax gravitates around functions and argument composition for functions.
-A core concept is, that everything is callable. It could be viewed as LISP
-without parenthesis. Or as a mixture of Perl, JavaScript and LISP/Scheme.
+This crate provides a small and simple embeddable scripting language.
+Its syntax gravitates around functions and argument composition for functions.
+A core concept is that everything is callable. It could be viewed as LISP
+without parenthesis, or as a mixture of Perl, JavaScript and LISP/Scheme.
 
-Here are some of it's properties:
+Here are some of its properties:
 
 - Simple but unique syntax. For a reference look at the [WLambda Language Reference](https://docs.rs/wlambda/newest/wlambda/prelude/index.html#wlambda-reference) and the [parser](https://docs.rs/wlambda/newest/wlambda/parser/index.html).
 - Easily embeddable into Rust programs due to a simple API.
@@ -514,7 +514,7 @@ assert_eq!(r.s(), "42");
 ## Possible Roadmap
 
 There are several things that can be added more or less easily to
-WLambda. But I am currently working on making the language more
+WLambda, but I am currently working on making the language more
 complete for real world use. So my current goals are:
 
 - Improve and further document the VVal API for interacting with WLambda.
@@ -523,7 +523,7 @@ complete for real world use. So my current goals are:
 - DONE: Add prototyped inheritance for OOP paradigm.
 - There are currently no plans to change the internal evaluator
 from a closure tree to a VM and/or JIT speedup.
-However, help is appreachiated if someone is able to significantly speed up the
+However, help is appreciated if someone is able to significantly speed up the
 evaluation without too much breakage.
 
 ## License


### PR DESCRIPTION
- favor complete sentences except when beginning lists and delimiting sections with short descriptions
- avoid starting sentences with and/or/but
- drop unnecessary already implied grammar, i.e. "This crate provides a" instead of "This crate provides you with a"
- [use `its` for possessive and `it's` for "it has" or "it is"](https://www.businesswritingblog.com/business_writing/2006/05/its_its_or_its_.html)